### PR TITLE
Add CyberSpectre security toolkit

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,27 @@
 # CyberSpectre
+
+CyberSpectre is a lightweight Python toolkit that integrates common open-source
+security tools to give a quick overview of your system.
+
+Features include:
+- Optional antivirus scanning using **ClamAV** on macOS/Linux or Windows Defender on Windows.
+- Basic port scanning via **nmap** if it is installed.
+- Simple search for potentially sensitive files (passwords, secrets, etc.).
+- Generates a JSON report with a basic score and findings summary.
+
+## Requirements
+- Python 3.8+
+- Optional: `nmap`, `clamscan` (for macOS/Linux), or Windows Defender (Windows).
+
+## Usage
+
+```
+python3 cyber_spectre.py --scan-path /path/to/scan --target localhost --report report.json
+```
+
+The script attempts to run `clamscan` (or Windows Defender) and `nmap` if they
+are available on the system. Results and a simple security score are written to
+the specified JSON report.
+
+> **Note**: This project is meant for educational purposes and does not replace
+> professional malware detection or comprehensive security auditing tools.

--- a/cyber_spectre.py
+++ b/cyber_spectre.py
@@ -1,0 +1,92 @@
+import os
+import sys
+import subprocess
+import json
+import shutil
+import re
+from pathlib import Path
+from typing import List, Dict
+
+
+def run_command(cmd: List[str]) -> Dict[str, str]:
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+        return {"cmd": " ".join(cmd), "stdout": result.stdout, "stderr": result.stderr, "returncode": result.returncode}
+    except Exception as e:
+        return {"cmd": " ".join(cmd), "error": str(e)}
+
+
+def scan_with_clamav(path: str) -> Dict[str, str]:
+    if shutil.which("clamscan"):
+        return run_command(["clamscan", "-r", path])
+    return {"error": "clamscan not installed"}
+
+
+def scan_with_nmap(target: str) -> Dict[str, str]:
+    if shutil.which("nmap"):
+        return run_command(["nmap", "-sV", target])
+    return {"error": "nmap not installed"}
+
+
+def scan_windows_defender(path: str) -> Dict[str, str]:
+    defender = shutil.which("powershell")
+    if defender and os.name == "nt":
+        cmd = ["powershell", "-Command", f"Start-MpScan -ScanPath {path}"]
+        return run_command(cmd)
+    return {"error": "Windows Defender not available"}
+
+
+def find_sensitive_files(base_path: Path) -> List[str]:
+    keywords = [re.compile(k, re.IGNORECASE) for k in ["password", "secret", "confidential", "private"]]
+    sensitive = []
+    for root, _, files in os.walk(base_path):
+        for name in files:
+            for kw in keywords:
+                if kw.search(name):
+                    sensitive.append(str(Path(root) / name))
+                    break
+    return sensitive
+
+
+def aggregate_score(results: Dict[str, Dict[str, str]]) -> int:
+    score = 100
+    for key, r in results.items():
+        if not isinstance(r, dict):
+            continue
+        if r.get("returncode", 0) != 0 or r.get("error"):
+            score -= 10
+    return max(score, 0)
+
+
+def main():
+    import argparse
+
+    parser = argparse.ArgumentParser(description="CyberSpectre - simple security overview tool")
+    parser.add_argument("--target", default="localhost", help="Target host for network scanning")
+    parser.add_argument("--scan-path", default=str(Path.home()), help="Path to scan for malware")
+    parser.add_argument("--report", default="cyber_report.json", help="Output report file")
+
+    args = parser.parse_args()
+
+    report = {}
+    if os.name == "nt":
+        report["defender"] = scan_windows_defender(args.scan_path)
+    else:
+        report["clamav"] = scan_with_clamav(args.scan_path)
+
+    report["nmap"] = scan_with_nmap(args.target)
+
+    sensitive_files = find_sensitive_files(Path(args.scan_path))
+    report["sensitive_files"] = sensitive_files
+
+    report["score"] = aggregate_score(report)
+
+    with open(args.report, "w") as fh:
+        json.dump(report, fh, indent=2)
+
+    print(f"Report written to {args.report}")
+    print(json.dumps({"score": report["score"], "findings": len(sensitive_files)}, indent=2))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create a lightweight Python script `cyber_spectre.py` that integrates optional tools like ClamAV, Windows Defender, and nmap
- search for potentially sensitive files and compile a basic security report
- document how to run the tool in `README.md`

## Testing
- `python3 -m py_compile cyber_spectre.py`
- `python3 cyber_spectre.py --scan-path . --target localhost --report sample_report.json`


------
https://chatgpt.com/codex/tasks/task_e_68564b99754483319530e31f07beb8cd